### PR TITLE
Explicit width for large resolutions

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -501,7 +501,7 @@ font-size:x-large;
 }
 
 .contentsection-main {
-  max-width: 93%;
+  width: 93%;
   height: auto;
   padding: 45px 0 0 0;
   margin: 0 auto;


### PR DESCRIPTION
In the Spanish version of the site, the width of the element is smaller than the space needed to show the game so the sidebar is on top of the game window.

This provides a temporary fix as I couldn't root cause the difference.

How verified:
Changed the language of my browser to Spanish and no longer saw the repro. Still looks good in english version.